### PR TITLE
chore(commitlint): increase header max-length to 100 chars

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -12,7 +12,8 @@ https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/con
 const Configuration: UserConfig = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'body-leading-blank': [RuleConfigSeverity.Error, 'always'], // changed from warning to error
+    'body-leading-blank': [RuleConfigSeverity.Error, 'always'], //* changed from warning to error; https://commitlint.js.org/reference/rules.html#body-leading-blank
+    'header-max-length': [RuleConfigSeverity.Error, 'always', 100], //* increased from 72 to 100 chars to offset optional (ticket number); https://commitlint.js.org/reference/rules.html#header-max-length
   },
 };
 


### PR DESCRIPTION
- Increase max-length for commit headers from 72 to 100 characters to allow optional ticket number