### PR TITLE
build(renovate): add baseBranches configuration to target dev

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["dev"],
   "extends": [
     "config:best-practices",
     "group:react",


### PR DESCRIPTION
Add 'baseBranches' field with ['dev'] to renovate.json configuration to specify the base branches for Renovate to target. This ensures updates are only applied to the 'dev' branch, aligning with current development workflow.