### PR TITLE
fix(renovate): update renovate config to use baseBranchPatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["dev"],
+  "baseBranchPatterns": [
+    "dev"
+  ],
   "extends": [
     "config:best-practices",
     "group:react",


### PR DESCRIPTION
Replace deprecated `baseBranches` with `baseBranchPatterns` in renovate.json to ensure correct branch targeting for dependency updates.