### PR TITLE
build(ci): add dev branch into CI workflow

### DIFF
--- a/.github/workflows/branch-check-dev.yml
+++ b/.github/workflows/branch-check-dev.yml
@@ -1,0 +1,18 @@
+name: 'Dev Branch Restriction Check'
+
+on:
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  guard-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject PRs from main → dev
+        if: github.head_ref == 'main'
+        run: |
+          echo "❌  Direct PRs from 'main' to 'dev' are disallowed."
+          exit 1
+      - name: Success
+        if: github.head_ref != 'main'
+        run: echo "✅  PR accepted"

--- a/.github/workflows/branch-check-main.yml
+++ b/.github/workflows/branch-check-main.yml
@@ -1,0 +1,19 @@
+name: 'Main Branch Restriction Check'
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  guard-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch
+        if: github.head_ref != 'dev'
+        run: |
+          echo "❌  Only pull requests from 'dev' may target 'main'."
+          echo "Current source branch: ${{ github.head_ref }}"
+          exit 1
+      - name: Success
+        if: github.head_ref == 'dev'
+        run: echo "✅  PR from dev → main is allowed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev] #* Not needed, just security fallback
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   validate:


### PR DESCRIPTION
- Update job configurations to run on both 'main' and 'dev' branches

build(ci): add workflow to restrict PRs from main to dev
build(ci): add workflow to restrict PRs to main only from dev- Update job configurations to run on both 'main' and 'dev' branches