### PR TITLE
ci(trivy): add image security scan CI workflow

### DIFF
--- a/.github/workflows/sbom-fs-pr-deps.yml
+++ b/.github/workflows/sbom-fs-pr-deps.yml
@@ -1,0 +1,47 @@
+name: SBOM (FS) - PR deps only
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/package-lock.json'
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-fs-pr:
+    name: Filesystem SBOM on PR (when package-lock.json changes)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: FS SBOM -> GitHub Dependency Graph
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'sbom'
+          format: 'github'
+          output: 'dependency-results.sbom.json'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 10
+
+      - name: FS SBOM (CycloneDX) artifact
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'sbom'
+          format: 'cyclonedx'
+          output: 'sbom.cyclonedx.json'
+        timeout-minutes: 10
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-fs-pr
+          path: |
+            dependency-results.sbom.json
+            sbom.cyclonedx.json
+          retention-days: 14

--- a/.github/workflows/sbom-image-main-schedule.yml
+++ b/.github/workflows/sbom-image-main-schedule.yml
@@ -1,0 +1,52 @@
+name: SBOM (Image) - main + weekly
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 4 * * 1' # Monday 04:00
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-image:
+    name: Image SBOM (main + weekly)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build -t alex-can-boilerplate-prod --target prod .
+          echo "Built image with tag: alex-can-boilerplate-prod"
+
+      - name: Image SBOM -> GitHub Dependency Graph
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'image'
+          image-ref: 'alex-can-boilerplate-prod'
+          scanners: 'sbom'
+          format: 'github'
+          output: 'image-dependency-results.sbom.json'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 15
+
+      - name: Image SBOM (CycloneDX) artifact
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'image'
+          image-ref: 'alex-can-boilerplate-prod'
+          scanners: 'sbom'
+          format: 'cyclonedx'
+          output: 'image-sbom.cyclonedx.json'
+        timeout-minutes: 15
+
+      - name: Upload Image SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-image-main
+          path: |
+            image-dependency-results.sbom.json
+            image-sbom.cyclonedx.json
+          retention-days: 30

--- a/.github/workflows/trivy-scan-image.yml
+++ b/.github/workflows/trivy-scan-image.yml
@@ -1,0 +1,44 @@
+name: Trivy Security Scan - Image
+
+on:
+  schedule:
+    # Weekly scan (monday 4:00)
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  image-scan:
+    name: Image (OS + app libraries CVEs)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build Docker image
+      run: |
+        docker build -t alex-can-boilerplate:${{ github.sha }} .
+        docker tag alex-can-boilerplate:${{ github.sha }} alex-can-boilerplate:latest
+
+    - name: Run Trivy image scan
+      uses: aquasecurity/trivy-action@0.30.0
+      with:
+          scan-type: 'image'
+          image-ref: 'alex-can-boilerplate:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-image-results.sarif'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+          ignore-unfixed: true
+          limit-severities-for-sarif: true
+          trivyignores: '.trivyignore'
+      timeout-minutes: 15
+
+    - name: Upload Image results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-image-results.sarif'


### PR DESCRIPTION
Add weekly scheduled image vulnerability scanning using Trivy. The workflow:
- Runs every Monday at 4:00 UTC
- Builds Docker image from current codebase
- Scans for critical/high severity OS and library vulnerabilities
- Uploads results to GitHub Security tab
- Ignores unfixed vulnerabilities via .trivyignore
- Fails pipeline if vulnerabilities found
- Uses sarif format for results reporting