### PR TITLE
chore(docker): adjust docker:stop command in npm script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # Development files
-renovate.json
+renovate.json5
 Dockerfile
 .dockerignore
 docker-compose.yml

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -18,7 +18,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**/*.js", "**/*.ts", "**/*.jsx", "**/*.tsx", "**/*.json", "!renovate.json"]
+    "includes": ["**/*.js", "**/*.ts", "**/*.jsx", "**/*.tsx", "**/*.json", "!renovate.json5"]
   },
   "formatter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "docker:dev": "docker-compose up dev",
     "docker:build": "docker-compose build prod",
     "docker:run": "docker-compose up -d prod",
-    "docker:stop": "docker-compose down prod",
+    "docker:stop": "docker-compose down",
     "trivy:code": "echo 'Scanning source code for vulnerabilities...' && docker-compose run --rm trivy --config trivy.yaml fs .",
     "trivy:image": "echo 'Scanning the Docker image for vulnerabilities...' && docker-compose run --rm trivy --config trivy.yaml image alex-can-boilerplate-prod",
     "trivy:build-scan": "echo 'Building Docker image and scanning image for vulnerabilities...' && npm run docker:build && npm run trivy:image",

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,7 @@
   ],
   "timezone": "Europe/Prague",
   "schedule": [
+    "after 3:15pm and before 4:20pm on Monday",
     "after 3:15pm and before 4:20pm on Thursday"
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
The 'docker:stop' script was updated to remove the 'prod' service name from
the 'docker-compose down' command. This ensures all containers are properly
stopped instead of targeting a single service, improving consistency with
other Docker commands.