### PR TITLE
ci(ci.yml): ignore docs and markdown files in CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI Pipeline
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 jobs:
   validate:


### PR DESCRIPTION
Add paths-ignore patterns to CI workflow triggers:
- Ignore all markdown files (**/*.md)
- Ignore entire docs directory (docs/**)
- Applies to both push and pull_request events on main branch
- Prevents unnecessary CI runs when only documentation changes