### PR TITLE
ci(tests.yml): add conditional test execution via inputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,37 @@ name: Test Pipeline
 
 on:
   workflow_call:
+    inputs:
+      run-unit:
+        type: boolean
+        default: true
+      run-component:
+        type: boolean
+        default: true
+      run-integration:
+        type: boolean
+        default: false
+      run-e2e:
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      run-unit:
+        description: 'Run unit tests?'
+        type: boolean
+        default: true
+      run-component:
+        description: 'Run component tests?'
+        type: boolean
+        default: true
+      run-integration:
+        description: 'Run integration tests?'
+        type: boolean
+        default: false
+      run-e2e:
+        description: 'Run E2E tests?'
+        type: boolean
+        default: false
 
 jobs:
   test-all:
@@ -31,19 +62,24 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run Unit tests
+        if: inputs.run-unit
         run: npm run test:unit
 
       - name: Run Component tests
+        if: inputs.run-component
         run: npm run test:component
 
       - name: Run Integration tests
+        if: inputs.run-integration
         run: npm run test:integration
 
   build-image:
+    if: inputs.run-e2e
     needs: test-all
     uses: ./.github/workflows/build-image.yml
 
   e2e:
+    if: inputs.run-e2e
     runs-on: ubuntu-latest
     needs: [build-image, test-all]
     permissions:


### PR DESCRIPTION
Add boolean inputs (run-unit, run-component, run-integration, run-e2e) to workflow_call and workflow_dispatch. Conditionally execute test steps and e2e jobs based on input values. Allows selective test runs for faster feedback during development.