### PR TITLE
fix(workflows): update packages permission from read to write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      packages: read
+      packages: write

--- a/.github/workflows/trivy-scan-image.yml
+++ b/.github/workflows/trivy-scan-image.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      packages: read
+      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Update GitHub Actions workflow permissions for Trivy image scanning. Change 'packages' permission from 'read' to 'write' to allow SBOM generation. This adjustment ensures the workflow can properly generate and upload security reports, aligning with security best practices.