### PR TITLE
chore(ci): disable e2e tests in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     uses: ./.github/workflows/e2e.yml
     with:
       image-tag: ${{ needs.build.outputs.image-tag }}
-      run-e2e: true
+      run-e2e: false
     permissions:          #* nested workflows cannot escalate permissions
       packages: read
       checks: write       #? needed for JUnit reporting tests.yml


### PR DESCRIPTION
Set run-e2e parameter to false in CI workflow configuration. This temporarily disables end-to-end test execution during builds.