### PR TITLE
fix(workflows): set minimum permissions for GitHub Actions jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  #? For node caching
     timeout-minutes: 10
 
     steps:
@@ -57,6 +60,9 @@ jobs:
       run-unit: true
       run-component: true
       run-integration: false
+    permissions:
+      contents: read
+      actions: write  #? For node caching
 
   e2e:
     needs: [ validate, build, tests ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  #? For node caching
     timeout-minutes: 15
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add 'contents: read' permissions to workflows in tests.yml and ci.yml.