### PR TITLE
fix(lefthook): enforce quotes around staged files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,12 +13,12 @@ pre-commit:
     depcheck:
       run: pnpm run dep-cruise:check
     lint:
-      run: pnpm run lint:staged -- {staged_files}
+      run: pnpm run lint:staged -- "{staged_files}"
 
 commit-msg:
   commands:
     "lint commit message":
-      run: pnpm run lint:commit -- {1}
+      run: pnpm run lint:commit -- "{1}"
 
 pre-push:
   commands:


### PR DESCRIPTION
Ensures staged files and commit messages are properly quoted when passed as arguments to pnpm scripts. This prevents potential issues with filenames or messages containing spaces or special characters.