### PR TITLE
ci(workflows): add fast-forward check and merge workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,25 @@ jobs:
       checks: write       #? needed for JUnit reporting tests.yml
       contents: read
 
+  check-fast-forward:
+    needs: [validate, build, tests]
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      #* We appear to need write permission for both pull-requests and
+      #* issues in order to post a comment to a pull request.
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checking if fast forwarding is possible
+        uses: sequoia-pgp/fast-forward@v1
+        with:
+          merge: false
+          comment: on-error
+
   trivy-image-scan:
     needs: build
     uses: ./.github/workflows/trivy-scan-image.yml

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,0 +1,26 @@
+name: Fast Forward ('/fast-forward')
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  fast-forward:
+    if: ${{ contains(github.event.comment.body, '/fast-forward') && github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: fast-forward-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Fast forwarding
+        uses: sequoia-pgp/fast-forward@v1
+        with:
+          github_token: ${{ secrets.FF_PUSH_TOKEN }}
+          merge: true
+          comment: always


### PR DESCRIPTION
Add CI job to check fast-forward mergebility after validate/build/tests. Uses sequoia-pgp/fast-forward action in check mode with commenting.

Add new workflow for performing fast-forward merges via '/fast-forward' comment trigger. Requires write permissions and FF_PUSH_TOKEN secret.