### PR TITLE
ci(fast-forward): pin fast-forward action to specific commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checking if fast forwarding is possible
-        uses: sequoia-pgp/fast-forward@v1
+        uses: sequoia-pgp/fast-forward@ea7628bedcb0b0b96e94383ada458d812fca4979 # v1
         with:
           merge: false
           comment: on-error

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Fast forwarding
-        uses: sequoia-pgp/fast-forward@v1
+        uses: sequoia-pgp/fast-forward@ea7628bedcb0b0b96e94383ada458d812fca4979 # v1
         with:
           github_token: ${{ secrets.FF_PUSH_TOKEN }}
           merge: true


### PR DESCRIPTION
Pin fast-forward GitHub Action to commit ea7628b in CI and fast-forward workflows to ensure stability and avoid unexpected changes from tag updates.