### PR TITLE
ci: remove tests from check-fast-forward job dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       contents: read
 
   check-fast-forward:
-    needs: [validate, build, tests]
+    needs: [validate, build]
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           github_token: ${{ secrets.FF_PUSH_TOKEN }}
           merge: true
-          comment: always
+          comment: on-error


### PR DESCRIPTION
Remove 'tests' from needs array in check-fast-forward workflow job. This
job no longer waits for tests completion before running, potentially
speeding up CI workflow validation steps.