### PR TITLE
docs(codecov): move config, add documentation and update references

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["aaron-bond.better-comments", "biomejs.biome"]
+  "recommendations": ["aaron-bond.better-comments", "biomejs.biome", "Codecov.codecov"]
 }

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@
 - Git hooks (pre-push) require Docker daemon to be running as they execute Trivy via docker-compose. Make sure Docker is running before pushing (Docker Desktop on Windows/macOS, dockerd on Linux); otherwise docker-compose will fail to start Trivy and the push will be blocked.
 
 - To run "depcruise:report" script [d2 diagram language](https://github.com/terrastruct/d2) is needed.
+
+## Tools
+This project uses several tools for code quality and monitoring:
+- **[Codecov](https://codecov.io/)** – Tracks code coverage from tests. See [docs/codecov.md](./docs/codecov.md) for details.
+- **Trivy** – Scans for vulnerabilities and misconfigurations (runs via Docker Compose).
+- **Biome** – Code linter and formatter.
+- **Dependency Cruiser** – Dependency analysis.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,2 @@
+## Monitoring Tools
+- Codecov: Used for code coverage reporting. Configuration file: `codecov.yml`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
       default:
         target: 50%
         threshold: 5%
-        informational: true
+        informational: true #* Until project base is established
 
 comment:
   layout: "reach,diff,flags,tree"

--- a/docs/codecov.md
+++ b/docs/codecov.md
@@ -1,0 +1,21 @@
+# Codecov Configuration
+This project uses [Codecov](https://codecov.io/) to report code coverage metrics. The configuration is in [codecov.yml](../codecov.yml).
+
+## Validation
+You can validate the configuration file using:
+- **Official [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Codecov.codecov)**
+- **PowerShell (Windows)**:  
+  `Invoke-RestMethod -Uri "https://codecov.io/validate" -Method Post -InFile "codecov.yml" -ContentType "application/octet-stream"`
+- **Bash/Shell (Linux/macOS)**:  
+  `curl -X POST --data-binary @codecov.yml https://codecov.io/validate`
+
+## Adjusting Settings
+- Target coverage values (`target` and `threshold`) can be modified in `codecov.yml`.
+- The default settings are conservative (50% coverage) for early project stages. As the project grows, consider the changing the config.
+- Refer to the [official Codecov documentation](https://docs.codecov.com/docs/common-recipe-list) for advanced options.
+
+## CI Integration
+Codecov runs automatically in the CI pipeline (see `.github/workflows/tests.yml`) and reports coverage results to pull requests.
+
+## Tip
+- Install Codecov **[Browser extension](https://docs.codecov.com/docs/the-codecov-browser-extension)**


### PR DESCRIPTION
- Move .codecov.yml to codecov.yml for consistency
- Add detailed Codecov documentation in docs/codecov.md
- Update README.md to reference Codecov docs and tools section
- Include Codecov in VSCode recommended extensions