### PR TITLE
chore: rename lint:commit to commitlint:check for clarity

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -22,19 +22,19 @@
 
 ## Code Quality & Tooling
 
-| Script            | What it does                                                                        | When to use                          |
-|-------------------|-------------------------------------------------------------------------------------|--------------------------------------|
-| `lint:check`      | Runs Biome linter in read-only mode                                                 | CI checks, manual verification       |
-| `lint:apply`      | Auto-fixes all fixable Biome issues                                                 | After writing new code               |
-| `lint:staged`     | Lints only Git staged files (used by pre-commit hook)                               | Automatic via Git hooks              |
-| `lint:commit`     | Validates commit message format (conventional commits)                              | Automatic via Git hooks              |
-| `check:types`     | TypeScript type checking without compilation                                        | CI pipeline, pre-push verification   |
-| `knip:check`      | Detects unused files, exports, and dependencies                                     | Weekly codebase cleanup              |
-| `knip:apply`      | Auto-removes detected unused code (use with caution)                                | After manual review of knip:check    |
-| `knip:prod`       | Production-focused unused code detection                                            | Pre-release cleanup                  |
-| `depcruise:check` | Validates import/dependency rules and architecture                                  | CI pipeline, architecture compliance |
-| `validate`        | Runs comprehensive checks: knip:prod + depcruise:check + check:types + lint         | One-command CI gate, pre-release     |
-| `prepare`         | This script prevents build failures in environments without Git caused by Lefthook. | Initial project setup                |
+| Script             | What it does                                                                        | When to use                          |
+|--------------------|-------------------------------------------------------------------------------------|--------------------------------------|
+| `lint:check`       | Runs Biome linter in read-only mode                                                 | CI checks, manual verification       |
+| `lint:apply`       | Auto-fixes all fixable Biome issues                                                 | After writing new code               |
+| `lint:staged`      | Lints only Git staged files (used by pre-commit hook)                               | Automatic via Git hooks              |
+| `commitlint:check` | Validates commit message format (conventional commits)                              | Automatic via Git hooks              |
+| `check:types`      | TypeScript type checking without compilation                                        | CI pipeline, pre-push verification   |
+| `knip:check`       | Detects unused files, exports, and dependencies                                     | Weekly codebase cleanup              |
+| `knip:apply`       | Auto-removes detected unused code (use with caution)                                | After manual review of knip:check    |
+| `knip:prod`        | Production-focused unused code detection                                            | Pre-release cleanup                  |
+| `depcruise:check`  | Validates import/dependency rules and architecture                                  | CI pipeline, architecture compliance |
+| `validate`         | Runs comprehensive checks: knip:prod + depcruise:check + check:types + lint         | One-command CI gate, pre-release     |
+| `prepare`          | This script prevents build failures in environments without Git caused by Lefthook. | Initial project setup                |
 
 **pre-commit**: Runs `knip:check`, `check:types`, `depcruise:check`, and `lint:staged`
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,7 @@ pre-commit:
 commit-msg:
   commands:
     "lint commit message":
-      run: pnpm run lint:commit -- "{1}"
+      run: pnpm run commitlint:check -- "{1}"
 
 pre-push:
   commands:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:check": "biome check .",
     "lint:apply": "biome check --write .",
     "lint:staged": "echo 'Running Biome linter...'; biome check --apply --no-errors-on-unmatched",
-    "lint:commit": "commitlint --edit",
+    "commitlint:check": "commitlint --edit",
     "check:types": "echo 'Checking TypeScript types...'; tsc --noEmit",
     "knip:check": "echo 'Running Knip check...' && knip",
     "knip:apply": "echo 'Running Knip auto-fix...' && knip --fix --format",


### PR DESCRIPTION
- Rename script from 'lint:commit' to 'commitlint:check' in docs/scripts.md
- Update corresponding package.json script command name
- Adjust lefthook.yml commit-msg hook to use new script name
- Maintain same functionality but align naming with commitlint tool
- Improve consistency with other lint-related script naming conventions