### PR TITLE
fix(scripts): correct depcruise script name in validate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "knip:prod": "echo 'Running Knip production check...' && knip --production",
     "depcruise:check": "depcruise .",
     "depcruise:report": "depcruise . -T html -f reports/depcruiser/depcruise.html && depcruise . -T d2 -f reports/depcruiser/depcruise.d2 && d2 reports/depcruiser/depcruise.d2 reports/depcruiser/depcruise.svg",
-    "validate": "pnpm run knip:prod && pnpm run dep-cruise:check && pnpm run check:types && pnpm run lint:check",
+    "validate": "pnpm run knip:prod && pnpm run depcruise:check && pnpm run check:types && pnpm run lint:check",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",


### PR DESCRIPTION
Fix typo in 'validate' script by changing 'dep-cruise:check' to 'depcruise:check'. This ensures the script correctly references the existing 'depcruise:check' command.